### PR TITLE
Globus cert verification does not clear proxy_depth or max_proxy_depth

### DIFF
--- a/src/GlobusSupport.cc
+++ b/src/GlobusSupport.cc
@@ -163,6 +163,9 @@ class VerifyCtx {
 
     // Initialize GSI callback data
     // proxy_depth variables need to be cleared before every validation
+    if (m_callback_data) {
+        globus_gsi_callback_data_destroy(m_callback_data);
+    }
     result = globus_gsi_callback_data_init(&m_callback_data);
     if (GLOBUS_SUCCESS != result) {
       globus_print(result);
@@ -222,6 +225,7 @@ class VerifyCtx {
 
     // Free GSI callback data
     globus_gsi_callback_data_destroy(m_callback_data);
+    m_callback_data = nullptr;
 
     return result;
   }
@@ -234,6 +238,10 @@ public:
     if (m_store_context)
     {
       X509_STORE_CTX_free(m_store_context);
+    }
+    if (m_callback_data)
+    {
+      globus_gsi_callback_data_destroy(m_callback_data);
     }
   }
 

--- a/src/GlobusSupport.cc
+++ b/src/GlobusSupport.cc
@@ -168,6 +168,7 @@ class VerifyCtx {
     }
     result = globus_gsi_callback_data_init(&m_callback_data);
     if (GLOBUS_SUCCESS != result) {
+      m_callback_data = nullptr;
       globus_print(result);
       return result;
     }

--- a/src/GlobusSupport.cc
+++ b/src/GlobusSupport.cc
@@ -139,17 +139,6 @@ class VerifyCtx {
     }
 
     globus_gsi_callback_get_X509_STORE_callback_data_index(&m_callback_data_index);
-
-    result = globus_gsi_callback_data_init(&m_callback_data);
-    if (GLOBUS_SUCCESS != result) {
-      globus_print(result);
-      throw result;
-    }
-    result = globus_gsi_callback_set_cert_dir(m_callback_data, g_cert_dir);
-    if (GLOBUS_SUCCESS != result) {
-      globus_print(result);
-      throw result;
-    }
   }
 
   void acquire(X509_STORE * cert_store) {m_cert_store = cert_store;}
@@ -169,6 +158,19 @@ class VerifyCtx {
 
     STACK_OF(X509) *cert_chain = nullptr;
     if (GLOBUS_SUCCESS != (result = globus_gsi_cred_get_cert_chain(cred_handle, &cert_chain))) {
+      return result;
+    }
+
+    // Initialize GSI callback data
+    // proxy_depth variables need to be cleared before every validation
+    result = globus_gsi_callback_data_init(&m_callback_data);
+    if (GLOBUS_SUCCESS != result) {
+      globus_print(result);
+      return result;
+    }
+    result = globus_gsi_callback_set_cert_dir(m_callback_data, g_cert_dir);
+    if (GLOBUS_SUCCESS != result) {
+      globus_print(result);
       return result;
     }
 
@@ -218,6 +220,9 @@ class VerifyCtx {
     // dynamically allocated structures.
     X509_STORE_CTX_cleanup(m_store_context);
 
+    // Free GSI callback data
+    globus_gsi_callback_data_destroy(m_callback_data);
+
     return result;
   }
 
@@ -229,10 +234,6 @@ public:
     if (m_store_context)
     {
       X509_STORE_CTX_free(m_store_context);
-    }
-    if (m_callback_data)
-    {
-      globus_gsi_callback_data_destroy(m_callback_data);
     }
   }
 


### PR DESCRIPTION
- proxy_depth is incremented and never cleared during validation
- max_proxy_depth is modified if the proxy has a path-length limit set

After a context validates a certificate with a path-length limit, subsequent validations may fail with "Proxy path length exceeded" errors.

Allocate a new callback struct before validation and free it when complete.