### PR TITLE
Call globus_activate() even if HTTP support is not enabled

### DIFF
--- a/src/XrdLcmaps.cc
+++ b/src/XrdLcmaps.cc
@@ -178,6 +178,8 @@ int XrdSecgsiAuthzInit(const char *cfg)
    int retval = XrdSecgsiAuthzConfig(cfg);
    if (retval) {return retval;}
 
+   if (!globus_activate()) {return -1;}
+
    // Done
    // 1 means 'OK and I want the certificate in PEM base64 format'
    return g_certificate_format;


### PR DESCRIPTION
If HTTP support is not enabled, verification context creation fails. g_cert_dir is initialized in globus_activate(), which is only called from XrdHttpLcmaps. Add the globus_activate() call to XrdLcmaps as well.