### PR TITLE
Small leak in globus_get_cert_and_chain()

### DIFF
--- a/src/GlobusSupport.cc
+++ b/src/GlobusSupport.cc
@@ -500,7 +500,6 @@ bool globus_get_cert_and_chain(const char * creds, size_t credslen, X509 **cert,
   // OpenSSL wiki states that BIO_new_mem_buf results in a read-only object,
   // meaning the const_cast ought to be safe.
   state.m_bio = BIO_new_mem_buf(const_cast<char *>(creds), credslen);
-  BIO_ctrl(state.m_bio, BIO_CTRL_SET_CLOSE, BIO_NOCLOSE, NULL);
   if (!state.m_bio) {
     std::cerr << "Unable to allocate new BIO object" << std::endl;
     return false;


### PR DESCRIPTION
Valgrind shows a leak of 24 bytes per GSI authentication in globus_get_cert_and_chain(). Running a test of 20 GSI authentications shows 20 lost blocks:

==32174== 480 bytes in 20 blocks are definitely lost in loss record 1,304 of 1,540
==32174==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==32174==    by 0x7DEE2D2: CRYPTO_malloc (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x7E5E179: BUF_MEM_new (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x7E5F758: ??? (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x7E5E711: BIO_set (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x7E5E781: BIO_new (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x7E5FBF1: BIO_new_mem_buf (in /usr/lib64/libcrypto.so.1.0.1e)
==32174==    by 0x9E15166: globus_get_cert_and_chain(char const*, unsigned long, x509_st**, stack_st_X509**) (GlobusSupport.cc:511)
==32174==    by 0x9E109AB: XrdSecgsiAuthzKey (XrdLcmaps.cc:151)
==32174==    by 0x99D36C7: XrdSecProtocolgsi::Authenticate(XrdSecBuffer*, XrdSecBuffer**, XrdOucErrInfo*) (in /usr/lib64/libXrdSecgsi-4.so)
==32174==    by 0x4E89251: XrdXrootdProtocol::do_Auth() (in /usr/lib64/libXrdServer.so.2.0.0)
==32174==    by 0x516BB17: XrdLink::DoIt() (in /usr/lib64/libXrdUtils.so.2.0.0)

It appears to be caused by BIO_NOCLOSE. The BIO is allocated with BIO_new_mem_buf(), so the data is treated as an unmanaged, read-only buffer. No need to set the BIO_NOCLOSE flag?