### PR TITLE
Use single shared mutex for LCMAPS calls from XrdLcmaps and XrdHttpLcmaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" "${LCMAPS_INCL
 
 add_library(XrdLcmaps MODULE src/XrdLcmaps.cc src/XrdHttpLcmaps.cc src/XrdLcmapsConfig.cc src/XrdLcmapsKey.cc src/GlobusSupport.cc src/GlobusError.cc)
 target_link_libraries(XrdLcmaps ${XROOTD_SECGSI} ${XROOTD_CRYPTOSSL} ${LCMAPS_LIB} ${DL_LIB} ${VOMS_LIB})
-set_target_properties(XrdLcmaps PROPERTIES LINK_FLAGS "-Wl,--version-script=configs/export-symbols")
+set_target_properties(XrdLcmaps PROPERTIES LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/configs/export-symbols")
 
 if (NOT DEFINED LIB_INSTALL_DIR)
   SET(LIB_INSTALL_DIR "lib")

--- a/src/XrdHttpLcmaps.cc
+++ b/src/XrdHttpLcmaps.cc
@@ -260,7 +260,7 @@ public:
         }
 
         // Grab the global mutex - lcmaps is not thread-safe.
-        std::lock_guard<std::mutex> guard(lcmaps_mutex);
+        std::lock_guard<std::mutex> guard(g_lcmaps_mutex);
 
         char  *poolindex = NULL;
         uid_t  uid = -1;

--- a/src/XrdHttpLcmaps.cc
+++ b/src/XrdHttpLcmaps.cc
@@ -260,7 +260,7 @@ public:
         }
 
         // Grab the global mutex - lcmaps is not thread-safe.
-        std::lock_guard<std::mutex> guard(m_mutex);
+        std::lock_guard<std::mutex> guard(lcmaps_mutex);
 
         char  *poolindex = NULL;
         uid_t  uid = -1;

--- a/src/XrdLcmaps.cc
+++ b/src/XrdLcmaps.cc
@@ -62,7 +62,7 @@ int XrdSecgsiAuthzFun(XrdSecEntity &entity)
    static const char inf_pfx[] = "INFO in AuthzFun: ";
 
    // Grab the global mutex.
-   std::lock_guard<std::mutex> guard(lcmaps_mutex);
+   std::lock_guard<std::mutex> guard(g_lcmaps_mutex);
 
    /* -1 is the mapcounter */
    // Need char, not const char.  Don't know if LCMAPS changes it.

--- a/src/XrdLcmaps.cc
+++ b/src/XrdLcmaps.cc
@@ -27,8 +27,6 @@
 #include <pwd.h>
 #include <dlfcn.h>
 
-#include "XrdSys/XrdSysPthread.hh"
-
 #include <XrdOuc/XrdOucString.hh>
 #include <XrdSec/XrdSecEntity.hh>
 
@@ -41,8 +39,6 @@ XrdVERSIONINFO(XrdSecgsiAuthzInit,secgsiauthz);
 extern "C"
 {
 #include "lcmaps_basic.h"
-
-XrdSysMutex mutex;
 
 int XrdSecgsiAuthzInit(const char *cfg);
 int XrdSecgsiAuthzFun(XrdSecEntity &entity);
@@ -66,7 +62,7 @@ int XrdSecgsiAuthzFun(XrdSecEntity &entity)
    static const char inf_pfx[] = "INFO in AuthzFun: ";
 
    // Grab the global mutex.
-   XrdSysMutexHelper lock(&mutex);
+   std::lock_guard<std::mutex> guard(lcmaps_mutex);
 
    /* -1 is the mapcounter */
    // Need char, not const char.  Don't know if LCMAPS changes it.

--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -4,6 +4,7 @@
 #include <getopt.h>
 
 #include <iostream>
+#include <mutex>
 
 extern "C" {
 #include <lcmaps.h>
@@ -133,3 +134,7 @@ int XrdSecgsiAuthzConfig(const char *cfg)
 
    return 0;
 }
+
+// lcmaps is not thread safe
+// Access is shared between XrdLcmaps and XrdHttpLcmaps
+std::mutex lcmaps_mutex;

--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -137,4 +137,4 @@ int XrdSecgsiAuthzConfig(const char *cfg)
 
 // lcmaps is not thread safe
 // Access is shared between XrdLcmaps and XrdHttpLcmaps
-std::mutex lcmaps_mutex;
+std::mutex g_lcmaps_mutex;

--- a/src/XrdLcmapsConfig.hh
+++ b/src/XrdLcmapsConfig.hh
@@ -1,6 +1,9 @@
 #ifndef __XRD_LCMAPS_CONFIG_HH
 #define __XRD_LCMAPS_CONFIG_HH
 
+#include <mutex>
+
 int XrdSecgsiAuthzConfig(const char *cfg);
+extern std::mutex lcmaps_mutex;
 
 #endif

--- a/src/XrdLcmapsConfig.hh
+++ b/src/XrdLcmapsConfig.hh
@@ -4,6 +4,6 @@
 #include <mutex>
 
 int XrdSecgsiAuthzConfig(const char *cfg);
-extern std::mutex lcmaps_mutex;
+extern std::mutex g_lcmaps_mutex;
 
 #endif


### PR DESCRIPTION
On a moderately busy xrootd system serving both xrootd and https protocols, we're seeing segfaults with varying code paths, but seeming to happen in this area:

    xrootd -> xrootd-lcmaps -> openssl -> globus -> openssl

I'm suspecting that it may be due to contention between the XrdLcmaps and XrdHttpLcmaps callouts to LCMAPS. If two calls happen simultaneously, memory will get corrupted and/or double-free'd.

This patch changes the mutex protecting LCMAPS such that both protocols are protected with a single mutex.