### PR TITLE
Add no-authz mode which skips LCMAPS.

### DIFF
--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -1,6 +1,6 @@
 
 Name: xrootd-lcmaps
-Version: 1.4.1
+Version: 1.5.0
 Release: 1%{?dist}
 Summary: LCMAPS plugin for xrootd
 
@@ -57,6 +57,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xrootd/lcmaps.cfg
 
 %changelog
+* Thu Nov 22 2018 Brian Bockelman <bbockelm@cse.unl.edu> - 1.5.0-1
+- Add mode to skip LCMAPS callout
+
 * Mon Sep 10 2018 Carl Edquist <edquist@cs.wisc.edu> - 1.4.1-1
 - Use single mutex for LCMAPS calls from XrdLcmaps and XrdHttpLcmaps (#16)
 - Drop OWNER_EXECUTE for lcmaps.cfg (#17)

--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -10,6 +10,9 @@ extern "C" {
 #include <lcmaps.h>
 }
 
+// Disable LCMAPS completely
+int g_no_authz = 0;
+
 static const char plugin_name [] = "XrdSecgsiAuthz";
 static const char default_db  [] = "/etc/lcmaps.db";
 static const char default_policy_name [] = "xrootd_policy";
@@ -71,6 +74,7 @@ int XrdSecgsiAuthzConfig(const char *cfg)
          {"lcmapscfg", required_argument, 0, 'c'},
          {"loglevel",  required_argument, 0, 'l'},
          {"policy",    required_argument, 0, 'p'},
+         {"no-authz",  no_argument, &g_no_authz, 1},
          {0, 0, 0, 0}
       };
       int option_index = 0;

--- a/src/XrdLcmapsConfig.hh
+++ b/src/XrdLcmapsConfig.hh
@@ -5,5 +5,6 @@
 
 int XrdSecgsiAuthzConfig(const char *cfg);
 extern std::mutex g_lcmaps_mutex;
+extern int g_no_authz;
 
 #endif


### PR DESCRIPTION
If `--no-authz` is passed to the Xrootd-LCMAPS module, then it will
skip the invocation of LCMAPS, meaning the username will not be filled
out.  Instead, the name will be inherited from Xrootd - either as the
DN or the OpenSSL subject hash.

With this mode, LCMAPS does not need to be setup on the host, nor does
a Unix user have to exist for each Xrootd mapping.