### PR TITLE
Fix no-authz mode for HTTP

### DIFF
--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -1,6 +1,6 @@
 
 Name: xrootd-lcmaps
-Version: 1.5.0
+Version: 1.5.1
 Release: 1%{?dist}
 Summary: LCMAPS plugin for xrootd
 
@@ -57,6 +57,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xrootd/lcmaps.cfg
 
 %changelog
+* Fri Dec 21 2018 Brian Bockelman <bbockelm@cse.unl.edu> - 1.5.1-1
+- As specified, skip callout for HTTP
+
 * Thu Nov 22 2018 Brian Bockelman <bbockelm@cse.unl.edu> - 1.5.0-1
 - Add mode to skip LCMAPS callout
 

--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -123,10 +123,12 @@ int XrdSecgsiAuthzConfig(const char *cfg)
       setenv("LCMAPS_DEBUG_LEVEL", log_level, 0);
    }
 
-   FILE *fp = fdopen(2, "w");
-   if (lcmaps_init_and_log(fp, 1)) {
-      PRINT(err_pfx << "Failed to initialize LCMAPS");
-      return -1;
+   if (!g_no_authz) {
+      FILE *fp = fdopen(2, "w");
+      if (lcmaps_init_and_log(fp, 1)) {
+         PRINT(err_pfx << "Failed to initialize LCMAPS");
+         return -1;
+      }
    }
 
    if (argv != NULL) {


### PR DESCRIPTION
Previously, no-authz mode was applied to only Xrootd-protocol-based mapping.  With this, it is not applied for HTTP and LCMAPS is not initialized.

Additionally, we now make sure to set the entity name to the DN hash for HTTP as it is done for Xrootd.