### PR TITLE
Copy the authz key into the monitoring info.

### DIFF
--- a/src/XrdHttpLcmaps.cc
+++ b/src/XrdHttpLcmaps.cc
@@ -320,6 +320,8 @@ public:
                 return -1;
             }
 
+            free(entity.moninfo);
+            entity.moninfo = strdup(key.c_str());
             free(entity.name);
             entity.name = strdup(pw->pw_name);
             mcache.try_put(key, entity);
@@ -346,6 +348,8 @@ public:
 
             sk_X509_free(full_stack);
             X509_free(peer_certificate);
+            free(entity.moninfo);
+            entity.moninfo = strdup(key.c_str());
             mcache.try_put(key, entity);
         }
         return 0;

--- a/src/XrdLcmaps.cc
+++ b/src/XrdLcmaps.cc
@@ -111,8 +111,8 @@ int XrdSecgsiAuthzFun(XrdSecEntity &entity)
       }
 
       // DN is in 'name' (--gmapopt=10), move it over to moninfo ...
-      free(entity.moninfo);
-      entity.moninfo = entity.name;
+      // free(entity.moninfo);
+      // entity.moninfo = entity.name;
       // ... and copy the local username into 'name'.
       entity.name = strdup(pw->pw_name);
 
@@ -167,6 +167,9 @@ int XrdSecgsiAuthzKey(XrdSecEntity &entity, char **key)
    memcpy(*key, skey.c_str(), skey.length());
    (*key)[skey.length()] = '\0';
    PRINT(inf_pfx << "Returning '" << skey << "' of length " << skey.length() << " as key.");
+
+   free(entity.moninfo);
+   entity.moninfo = strdup(skey.c_str());
    return skey.length() + 1;
 }
 


### PR DESCRIPTION
Some GSI modes map the DN hash to the `XrdSecEntity.name` structure, meaning that our monitoring no longer receives the actual DN - a significant decrease in capabilities.

This causes the LCMAPS plugin to always copy the authz key (a concatenation of the DN and VOMs attributes) into the moninfo; the monitoring system can fallback to utilizing this info when the DN hash is reported as the name.

With this, the decoded monitoring packet from the server has the following information (for both `xrootd` and HTTP protocols):

```
dn='6fb7593d.0',
info='/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian Paul Bockelman::dteam:/dteam,::'
```

Without this, the monitoring packet has (for the `xrootd` protocol):

```
dn='6fb7593d.0',
info='6fb7593d.0'
```

For the HTTP protocol, the `info` attribute was always left blank.