### PR TITLE
Get rid of "macro expanded in comment" warning

### DIFF
--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -8,7 +8,7 @@ Group: System Environment/Daemons
 License: BSD
 URL: https://github.com/opensciencegrid/xrootd-lcmaps
 # Generated from:
-# git archive v%{version} --prefix=xrootd-lcmaps-%{version}/ | gzip -7 > ~/rpmbuild/SOURCES/xrootd-lcmaps-%{version}.tar.gz
+# git archive v${VERSION} --prefix=xrootd-lcmaps-$VERSION/ | gzip -7 > ~/rpmbuild/SOURCES/xrootd-lcmaps-$VERSION.tar.gz
 Source0: %{name}-%{version}.tar.gz
 BuildRequires: xrootd-server-libs >= 1:4.1.0
 BuildRequires: xrootd-server-devel >= 1:4.1.0


### PR DESCRIPTION
%macros in spec files get expanded in comments but rpmbuild gives a warning about this. Use shell syntax ($ instead of %) to avoid the warning, although I'm not sure we even need the comment at this point...