### PR TITLE
Bump version to 1.7.3 (SOFTWARE-3534)

### DIFF
--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -1,6 +1,6 @@
 
 Name: xrootd-lcmaps
-Version: 1.7.2
+Version: 1.7.3
 Release: 1%{?dist}
 Summary: LCMAPS plugin for xrootd
 
@@ -68,6 +68,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %config %{_sysconfdir}/xrootd/config.d/40-xrootd-lcmaps.cfg
 
 %changelog
+* Fri Aug 01 2019 Brian Lin <blin@cs.wisc.edu> - 1.7.3-1
+- Add support for unauthenticated Stash Caches and Origins
+
 * Fri Jul 26 2019 Diego Davila <didavila@ucsd.edu> - 1.7.2-1
 - Adding 40-xrootd-lcmaps.cfg to CMakeLists.txt
 - Adding .travis.yml

--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -68,8 +68,10 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %config %{_sysconfdir}/xrootd/config.d/40-xrootd-lcmaps.cfg
 
 %changelog
-* Fri Aug 01 2019 Brian Lin <blin@cs.wisc.edu> - 1.7.3-1
+* Thu Aug 01 2019 Brian Lin <blin@cs.wisc.edu> - 1.7.3-1
 - Add support for unauthenticated Stash Caches and Origins
+- Fix authzfunparms syntax
+- Use the canonical LCMAPS config location in the default config
 
 * Fri Jul 26 2019 Diego Davila <didavila@ucsd.edu> - 1.7.2-1
 - Adding 40-xrootd-lcmaps.cfg to CMakeLists.txt


### PR DESCRIPTION
The versioning here looks pretty stale: https://github.com/opensciencegrid/xrootd-lcmaps/blob/master/CMakeLists.txt#L57-L58

Should we bump them? If so, what to?

EDIT: The last time the `src/` dir was touched was for 1.7.0