### PR TITLE
Fixup LCMAPS options in the default config (SOFTWARE-3534)

### DIFF
--- a/configs/config.d/40-xrootd-lcmaps.cfg
+++ b/configs/config.d/40-xrootd-lcmaps.cfg
@@ -22,7 +22,7 @@ else
                        -key:/etc/grid-security/xrd/xrdkey.pem \
                        -crl:1 \
                        -authzfun:libXrdLcmaps.so \
-                       -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,--loglevel=0,--policy=authorize_only \
+                       -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,loglevel=0,policy=authorize_only \
                        -gmapopt:10 -gmapto:0
 
    acc.authdb /etc/xrootd/auth_file

--- a/configs/config.d/40-xrootd-lcmaps.cfg
+++ b/configs/config.d/40-xrootd-lcmaps.cfg
@@ -22,7 +22,7 @@ else
                        -key:/etc/grid-security/xrd/xrdkey.pem \
                        -crl:1 \
                        -authzfun:libXrdLcmaps.so \
-                       -authzfunparms:lcmapscfg=/etc/xrootd/lcmaps.cfg,loglevel=0,policy=authorize_only \
+                       -authzfunparms:lcmapscfg=/etc/lcmaps.db,loglevel=0,policy=authorize_only \
                        -gmapopt:10 -gmapto:0
 
    acc.authdb /etc/xrootd/auth_file


### PR DESCRIPTION
Today's a good day for PRs. 

This default will work well for XRootD standalone and SE installations since we already tell our users to configure [LCMAPS VOMS](https://opensciencegrid.org/docs/security/lcmaps-voms-authentication/), i.e. they're using the canonical `/etc/lcmaps.db` location.

On the other hand, caches and origins already ship their own [sec.protocol config](https://github.com/opensciencegrid/xcache/blob/master/configs/stash-cache/config.d/50-stash-cache-authz.cfg#L35) that uses LCMAPS to just validate the proxy, i.e. `no-authz`. 