### PR TITLE
rebuild against xrootd 4.11 (SOFTWARE-3830)

### DIFF
--- a/rpm/xrootd-lcmaps.spec
+++ b/rpm/xrootd-lcmaps.spec
@@ -1,7 +1,7 @@
 
 Name: xrootd-lcmaps
 Version: 1.7.4
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: LCMAPS plugin for xrootd
 
 Group: System Environment/Daemons
@@ -10,7 +10,12 @@ URL: https://github.com/opensciencegrid/xrootd-lcmaps
 # Generated from:
 # git archive v${VERSION} --prefix=xrootd-lcmaps-$VERSION/ | gzip -7 > ~/rpmbuild/SOURCES/xrootd-lcmaps-$VERSION.tar.gz
 Source0: %{name}-%{version}.tar.gz
-BuildRequires: xrootd-server-devel >= 1:4.10, xrootd-server-devel < 1:4.11.0-1
+
+%define xrootd_current 4.11
+%define xrootd_next %(echo %xrootd_current | awk '{print $1,$2+1}' FS=. OFS=.)
+
+BuildRequires: xrootd-server-devel >= 1:%{xrootd_current}.0-1
+BuildRequires: xrootd-server-devel <  1:%{xrootd_next}.0-1
 BuildRequires: lcmaps-interface
 BuildRequires: lcmaps
 BuildRequires: cmake
@@ -30,7 +35,8 @@ BuildRequires: globus-common-devel
 BuildRequires: globus-gsi-sysconfig-devel
 BuildRequires: globus-gsi-callback-devel
 
-Requires: xrootd-server >= 1:4.10, xrootd-server < 1:4.11.0-1
+Requires: xrootd-server >= 1:%{xrootd_current}.0-1
+Requires: xrootd-server <  1:%{xrootd_next}.0-1
 
 %description
 %{summary}
@@ -68,6 +74,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %config %{_sysconfdir}/xrootd/config.d/40-xrootd-lcmaps.cfg
 
 %changelog
+* Mon Oct 21 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.7.4-4
+- Rebuild against xrootd 4.11 (SOFTWARE-3830)
+
 * Tue Sep 17 2019 Diego Davila <didavila@ucsd.edu> - 1.7.4-3
 - Enforce building and installing with same version of xrootd
 


### PR DESCRIPTION
the new `xrootd_current` macro is set up like in https://github.com/opensciencegrid/xrootd-hdfs/pull/23