### PR TITLE
allow lcmaps policy to be read from config file

### DIFF
--- a/src/XrdHttpLcmaps.cc
+++ b/src/XrdHttpLcmaps.cc
@@ -276,7 +276,8 @@ public:
             lcmaps_request_t request = NULL; // Typically, the RSL
 
             // To manage const cast issues
-            char * policy_name_copy = strdup(default_policy_name);
+            const char * policy_name_env = getenv("LCMAPS_POLICY_NAME");
+            char * policy_name_copy = strdup(policy_name_env ? policy_name_env : default_policy_name);
 
             int rc = lcmaps_run_with_stack_of_x509_and_return_account(
                 full_stack,


### PR DESCRIPTION
This PR solves the problem of having a policy other than the default "xrootd_policy"  e.g. "authorize_only" on --authzfunparms and then having a http request failing to find that policy[1]. It always tries to find the default one. Notice that this is only tru for 'http', when using 'root', things work fine.

[1]
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: lcmaps.mod-lcmaps_runPluginManager():     xrootd_policy
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: evaluationmanager: found plugin: lcmaps_verify_proxy2.mod
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: evaluationmanager: No more policies to run
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: lcmaps.mod-lcmaps_runPluginManager(): Error running evaluation manager
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: Credential Print:
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: lcmaps_run_with_stack_of_x509_and_return_account() error: could not run plugin manager
lcmaps[15907]   LOG_DEBUG: 2020-01-09.18:28:00Z: lcmaps_run_with_stack_of_x509_and_return_account(): failed
ERROR in AuthzFun: LCMAPS failed or denied mapping
