### PR TITLE
make the initial log to show the actual policy selected

### DIFF
--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -147,8 +147,8 @@ int XrdSecgsiAuthzConfig(const char *cfg)
                   cfg_file = value;
                   PRINT(inf_pfx << "XrdLcmaps: Setting LCMAPS config file to " << cfg_file << ".");
               } else if (key == "policy") {
-                  PRINT(inf_pfx << "XrdLcmaps: Using LCMAPS policy name " << policy_name << ".");
                   policy_name = value;
+                  PRINT(inf_pfx << "XrdLcmaps: Using LCMAPS policy name " << policy_name << ".");
               } else if (key == "loglevel") {
                   log_level = value;
                   PRINT(inf_pfx << "XrdLcmaps: Setting LCMAPS log level to " << log_level << ".");


### PR DESCRIPTION
Currently the initial log always show the default policy instead of the policy set in the configuration file[1]. Note that It is just the logging which is wrong, the behavior is ok.

[1]
200424 17:59:28 28769 secgsi_InitOpts:  Authorization function parms: lcmapscfg=/etc/lcmaps.db,loglevel=5,policy=**authorize_only**,no-authz
...
INFO in xrootd-lcmaps config: XrdLcmaps: Using LCMAPS policy name **xrootd_policy.**