### PR TITLE
Include "Bypass voms MT initialization issues" fix from xrootd

### DIFF
--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -11,6 +11,8 @@ extern "C" {
 #include <lcmaps.h>
 }
 
+#include <voms/voms_api.h>
+
 // Disable LCMAPS completely
 int g_no_authz = 0;
 
@@ -189,6 +191,7 @@ int XrdSecgsiAuthzConfig(const char *cfg)
       PRINT(inf_pfx << " LCMAPS: no-authz option is set; LCMAPS will not be invoked");
    }
 
+   vomsdata vomsInit; // This forces libssl initialization at load time
 
    if (argv != NULL) {
       for (int i=0; i<argc+1; i++) {

--- a/src/XrdLcmapsKey.cc
+++ b/src/XrdLcmapsKey.cc
@@ -43,6 +43,12 @@ GetKey(X509 *cert, STACK_OF(X509) *chain, XrdSecEntity &ent)
 
     // Parse VOMS data and append that.
     struct vomsdata *voms_ptr = VOMS_Init(NULL, NULL);
+    if (voms_ptr == nullptr)
+    {
+        std::cerr << "VOMS failure: VOMS_Init() returned NULL" << std::endl;
+        return key.str();
+    }
+
     int errcode = 0;
     if (!VOMS_Retrieve(cert, chain, RECURSE_CHAIN, voms_ptr, &errcode))
     {


### PR DESCRIPTION
Include VOMS initialization fix from https://github.com/xrootd/xrootd/commit/d9e9820b329ffb6e33ac8837bf8a6cadc1beee25.

Wasn't able to make it into a neat one-line change (xrootd uses the C++ API). To avoid declaration conflicts, I ended up creating a `VOMS_Init_SSL()` function and calling it from `XrdSecgsiAuthzConfig()`.

Suggestions @bbockelm ?