### PR TITLE
Fix log message

### DIFF
--- a/src/XrdLcmapsConfig.cc
+++ b/src/XrdLcmapsConfig.cc
@@ -165,7 +165,7 @@ int XrdSecgsiAuthzConfig(const char *cfg)
                   if (g_no_authz) {
                       PRINT(warn_pfx << "LCMAPS log level " << log_level << " won't be used: no-authz option is set.");
                   } else {
-                      PRINT(inf_pfx << "XrdLcmaps: Using LCMAPS policy name " << policy_name << ".");
+                      PRINT(inf_pfx << "XrdLcmaps: Setting LCMAPS log level to " << log_level << ".");
                   }
               } else {
                   std::cerr << "Unknown configuration directive: " << item << std::endl;


### PR DESCRIPTION
Hi,

this change removes the extra/spurious line for the policy name, and adds the one for the log level

Best regards,
Giuseppe.

before:

INFO in xrootd-lcmaps config: XrdLcmaps: Setting LCMAPS config file to /etc/xrootd/lcmaps.conf.
INFO in xrootd-lcmaps config: XrdLcmaps: Using LCMAPS policy name xrootd_policy.
INFO in xrootd-lcmaps config: XrdLcmaps: Using LCMAPS policy name xrootd_policy.

after:

INFO in xrootd-lcmaps config: XrdLcmaps: Setting LCMAPS config file to /etc/xrootd/lcmaps.conf.
INFO in xrootd-lcmaps config: XrdLcmaps: Using LCMAPS policy name xrootd_policy.
INFO in xrootd-lcmaps config: XrdLcmaps: Setting LCMAPS log level to 0.
